### PR TITLE
Fix BER encoding bug

### DIFF
--- a/lib/ASN1.js
+++ b/lib/ASN1.js
@@ -28,7 +28,7 @@ var ASN1 = {
             tlv = new Buffer(1 + 3 + payload.length);
             tlv.writeUInt8(dertype, 0);
             tlv.writeUInt8(utils.toBinary('10000010'), 1); // Number of length bytes = 2
-            tlv.writeUInt16LE(payload.length, 2);
+            tlv.writeUInt16BE(payload.length, 2);
             offset = 4;
         }
 


### PR DESCRIPTION
 According to X.690 standard, the encoding should be big-endian. This affected messages larger than 256 bytes.