### PR TITLE
add user data even if connection is forbidden

### DIFF
--- a/lib/express-ntlm.js
+++ b/lib/express-ntlm.js
@@ -168,22 +168,21 @@ module.exports = function(options) {
         }
         proxy.authenticate(ntlm_message, function(error, result) {
             if (error) return callback(error);
+            var userData = {
+                DomainName: domain,
+                UserName: user,
+                Workstation: workstation
+            };
+
+            request.ntlm = userData;
+            response.locals.ntlm = userData;
+            request.connection.ntlm = userData;
 
             if (!result) {
                 cache.remove(request.connection.id);
                 options.debug(options.prefix, 'User ' + domain + '/' + user + ' authentication for URI ' + request.protocol + '://' + request.get('host') + request.originalUrl);
                 return options.forbidden(request, response, next);
             } else {
-                var userData = {
-                    DomainName: domain,
-                    UserName: user,
-                    Workstation: workstation
-                };
-
-                request.ntlm = userData;
-                response.locals.ntlm = userData;
-                request.connection.ntlm = userData;
-
                 return next();
             }
         });


### PR DESCRIPTION
First of all, let me thank your for your project, it really helped me a lot! 
The improvement that I suggest covers the case where authentication was not successful, but you need to know the user name for further processing. Sure, I could also parse args for the debug function, but this additional complexity is unnecessary, if I could get the user data directly.
So what do you think on this PR?