### PR TITLE
Don't fail completely if the first domain controller fails.

### DIFF
--- a/lib/express-ntlm.js
+++ b/lib/express-ntlm.js
@@ -121,7 +121,8 @@ module.exports = function(options) {
                 if (error) {
                     proxy.close();
                     proxy = null;
-                    return eachDomaincontrollerCallback(error);
+                    options.debug(options.prefix, error);
+                    return eachDomaincontrollerCallback();
                 }
 
                 ntlm_challenge = challenge;


### PR DESCRIPTION
If an error is supplied to `eachDomaincontrollerCallback`, `eachSeries` stops processing the rest of the array (The async documentation, doesn't mention this). Basically, if the first one fails, the rest aren't tried. 

With this change, only the error "None of the Domain Controllers are available" will be returned to the callback instead of the actual error that caused the failure, so I logged the connection errors to the debug log.