### PR TITLE
Add options.getConnectionId function

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ It's not recommended, but it's possible to add NTLM-Authentication without valid
 | `domaincontroller` | `null` / `string` / `array` | `null` | One or more domaincontroller(s) to handle the authentication. If `null` is specified the user is not validated. Active Directory is supported. |
 | `tlsOptions` | `object` | `undefined` | An options object that will be passed to [tls.connect](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback) and [tls.createSecureContext](https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options). __Only required when using ldaps and the server's certificate is signed by a certificate authority not in Node's default list of CAs.__ (or use [NODE_EXTRA_CA_CERTS](https://nodejs.org/api/cli.html#cli_node_extra_ca_certs_file) environment variable)|
 | `tlsOptions.ca` | `string` /  `array` / `Buffer` | `undefined` | Override the trusted CA certificates provided by Node. Refer to [tls.createSecureContext](https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options) |
+| `getConnectionId` | `function` | `function(request, response) { return utils.uuidv4(); }` | Function to generate custom connection IDs, based optionally on the request and response objects. |
 
 ## logging (examples)
 <a name="logging" />

--- a/lib/express-ntlm.js
+++ b/lib/express-ntlm.js
@@ -42,7 +42,11 @@ module.exports = function(options) {
 
         },
 
-        domaincontroller: null
+        domaincontroller: null,
+
+        getConnectionId(request, response) {
+            return utils.uuidv4();
+        }
     }, options);
 
     function ntlm_message_type(msg) {
@@ -193,7 +197,7 @@ module.exports = function(options) {
 
     return function(request, response, next) {
         if (!request.connection.id) {
-            request.connection.id = utils.uuidv4();
+            request.connection.id = options.getConnectionId(request, response);
         }
 
         var auth_headers = request.headers.authorization;


### PR DESCRIPTION
Adds the ability to pass a new custom function to the options object, returning a connection ID based upon properties of the request and/or response objects, in cases where a random UUID is insufficient. UUID remains the default.

Usage:

```js
app.use(ntlm({
  getConnectionId: (req, res) => req.get('X-Some-Unique-Header')
});
```