### PR TITLE
NTLMv2 support

### DIFF
--- a/lib/NTLM_No_Proxy.js
+++ b/lib/NTLM_No_Proxy.js
@@ -6,48 +6,44 @@ NTLM_No_Proxy.prototype.close = function() {
     
 };
 
+const NEGOTIATE_OEM         = 1 << 1;
+const REQUEST_TARGET        = 1 << 2;
+const TARGET_TYPE_DOMAIN    = 1 << 16;
+const NEGOTIATE_NTLM2_KEY   = 1 << 19;
+const NEGOTIATE_TARGET_INFO = 1 << 23;
+
 NTLM_No_Proxy.prototype.negotiate = function(ntlm_negotiate, negotiate_callback) {
-    var challenge = new Buffer(40),
+    const targetName = 'ALPHA';
+    const flags = NEGOTIATE_OEM || REQUEST_TARGET || TARGET_TYPE_DOMAIN || NEGOTIATE_NTLM2_KEY || NEGOTIATE_TARGET_INFO;
+    var challenge = new Buffer(40 + targetName.length),
         offset = 0;
 
-    var header = 'NTLMSSP\0';
-    for (var i = 0; i < header.length; i++) {
-        challenge.writeUInt8(header.charCodeAt(i), offset++);
-    }
+    const header = 'NTLMSSP\0';
+    offset += challenge.write(header, 0, 'ascii');
 
-    challenge.writeUInt8(0x02, offset++);
-    challenge.writeUInt8(0x00, offset++);
-    challenge.writeUInt8(0x00, offset++);
-    challenge.writeUInt8(0x00, offset++);
-    challenge.writeUInt8(0x00, offset++);
-    challenge.writeUInt8(0x00, offset++);
-    challenge.writeUInt8(0x00, offset++);
-    challenge.writeUInt8(0x00, offset++);
-    challenge.writeUInt8(0x00, offset++);
-    challenge.writeUInt8(0x28, offset++);
-    challenge.writeUInt8(0x00, offset++);
-    challenge.writeUInt8(0x00, offset++);
-    challenge.writeUInt8(0x01, offset++);
-    challenge.writeUInt8(0x82, offset++);
-    challenge.writeUInt8(0x00, offset++);
-    challenge.writeUInt8(0x00, offset++);
-    challenge.writeUInt8(0x01, offset++);
-    challenge.writeUInt8(0x23, offset++);
-    challenge.writeUInt8(0x45, offset++);
-    challenge.writeUInt8(0x67, offset++);
-    challenge.writeUInt8(0x89, offset++);
-    challenge.writeUInt8(0xab, offset++);
-    challenge.writeUInt8(0xcd, offset++);
-    challenge.writeUInt8(0xef, offset++);
-    challenge.writeUInt8(0x00, offset++);
-    challenge.writeUInt8(0x00, offset++);
-    challenge.writeUInt8(0x00, offset++);
-    challenge.writeUInt8(0x00, offset++);
-    challenge.writeUInt8(0x00, offset++);
-    challenge.writeUInt8(0x00, offset++);
-    challenge.writeUInt8(0x00, offset++);
-    challenge.writeUInt8(0x00, offset++);
-    
+    // Type 2 message
+    offset = challenge.writeUInt32LE(0x00000002, offset);
+
+    // Target name security buffer
+    offset = challenge.writeUInt16LE(targetName.length, offset);
+    offset = challenge.writeUInt16LE(targetName.length, offset);
+    offset = challenge.writeUInt32LE(40, offset);
+
+    // Flags
+    offset = challenge.writeUInt32LE(flags, offset);
+
+    // Server challenge
+    offset = challenge.writeUInt32LE(0x89abcdef, offset);
+    offset = challenge.writeUInt32LE(0x01234567, offset);
+
+    // Context
+    offset = challenge.writeUInt32LE(0, offset);
+    offset = challenge.writeUInt32LE(0, offset);
+
+    // Target name data
+    offset += challenge.write(targetName, offset, 'ascii');
+    console.log(challenge.toString('base64'));
+
     negotiate_callback(null, challenge);
 };
 

--- a/lib/NTLM_No_Proxy.js
+++ b/lib/NTLM_No_Proxy.js
@@ -3,20 +3,38 @@
 function NTLM_No_Proxy() {}
 
 NTLM_No_Proxy.prototype.close = function() {
-    
+
 };
 
 const NEGOTIATE_OEM         = 1 << 1;
 const REQUEST_TARGET        = 1 << 2;
+const NEGOTIATE_NTLM_KEY    = 1 << 9;
 const TARGET_TYPE_DOMAIN    = 1 << 16;
 const NEGOTIATE_NTLM2_KEY   = 1 << 19;
 const NEGOTIATE_TARGET_INFO = 1 << 23;
 
 NTLM_No_Proxy.prototype.negotiate = function(ntlm_negotiate, negotiate_callback) {
-    const targetName = 'ALPHA';
-    const flags = NEGOTIATE_OEM || REQUEST_TARGET || TARGET_TYPE_DOMAIN || NEGOTIATE_NTLM2_KEY || NEGOTIATE_TARGET_INFO;
-    var challenge = new Buffer(40 + targetName.length),
-        offset = 0;
+    const target_name = 'ALPHA';
+    let challenge_flags = NEGOTIATE_OEM | REQUEST_TARGET | TARGET_TYPE_DOMAIN;
+
+    // Follow requested NTLM protocol version
+    const request_flags = ntlm_negotiate.readUInt32LE(12);
+    const ntlm_version = request_flags & NEGOTIATE_NTLM2_KEY ? 2 : 1;
+    let header_len;
+    let data_len;
+
+    if (ntlm_version === 2) {
+      challenge_flags |= NEGOTIATE_NTLM2_KEY | NEGOTIATE_TARGET_INFO;
+      header_len = 40 + 8;
+      data_len = target_name.length + ((2 * target_name.length) + 8);
+    } else {
+      challenge_flags |= NEGOTIATE_NTLM_KEY;
+      header_len = 40;
+      data_len = target_name.length
+    }
+
+    let challenge = new Buffer(header_len + data_len);
+    let offset = 0;
 
     const header = 'NTLMSSP\0';
     offset += challenge.write(header, 0, 'ascii');
@@ -25,12 +43,12 @@ NTLM_No_Proxy.prototype.negotiate = function(ntlm_negotiate, negotiate_callback)
     offset = challenge.writeUInt32LE(0x00000002, offset);
 
     // Target name security buffer
-    offset = challenge.writeUInt16LE(targetName.length, offset);
-    offset = challenge.writeUInt16LE(targetName.length, offset);
-    offset = challenge.writeUInt32LE(40, offset);
+    offset = challenge.writeUInt16LE(target_name.length, offset);
+    offset = challenge.writeUInt16LE(target_name.length, offset);
+    offset = challenge.writeUInt32LE(header_len, offset);
 
     // Flags
-    offset = challenge.writeUInt32LE(flags, offset);
+    offset = challenge.writeUInt32LE(challenge_flags, offset);
 
     // Server challenge
     offset = challenge.writeUInt32LE(0x89abcdef, offset);
@@ -40,9 +58,24 @@ NTLM_No_Proxy.prototype.negotiate = function(ntlm_negotiate, negotiate_callback)
     offset = challenge.writeUInt32LE(0, offset);
     offset = challenge.writeUInt32LE(0, offset);
 
+    if (ntlm_version === 2) {
+      // Target info security buffer
+      offset = challenge.writeUInt16LE(target_name.length * 2 + 8, offset);
+      offset = challenge.writeUInt16LE(target_name.length * 2 + 8, offset);
+      offset = challenge.writeUInt32LE(header_len + target_name.length, offset);
+    }
+
     // Target name data
-    offset += challenge.write(targetName, offset, 'ascii');
-    console.log(challenge.toString('base64'));
+    offset += challenge.write(target_name, offset, 'ascii');
+
+    if (ntlm_version === 2) {
+      // Target info data
+      offset = challenge.writeUInt16LE(0x0200, offset); // Domain
+      offset = challenge.writeUInt16LE(target_name.length * 2, offset);
+      offset += challenge.write(target_name, offset, 'ucs2');
+      offset = challenge.writeUInt16LE(0x0000, offset); // Terminator block
+      offset = challenge.writeUInt16LE(0, offset);
+    }
 
     negotiate_callback(null, challenge);
 };


### PR DESCRIPTION
When using express-ntlm without validation, it always sent a NTLMv1 challenge. On modern versions of Windows, it is a common setting that NTLMv1 authentication is denied - hence authentication against express-ntlm would fail.

This PR makes the challenge message both NTLMv1 and NTLMv2 compliant. The flags of the incoming authentication request are inspected to determine the proper version to use for the response.