### PR TITLE
Support usage behind a proxy if the application can distinguish its user

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,10 @@ It's not recommended, but it's possible to add NTLM-Authentication without valid
 | `domaincontroller` | `null` / `string` / `array` | `null` | One or more domaincontroller(s) to handle the authentication. If `null` is specified the user is not validated. Active Directory is supported. |
 | `tlsOptions` | `object` | `undefined` | An options object that will be passed to [tls.connect](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback) and [tls.createSecureContext](https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options). __Only required when using ldaps and the server's certificate is signed by a certificate authority not in Node's default list of CAs.__ (or use [NODE_EXTRA_CA_CERTS](https://nodejs.org/api/cli.html#cli_node_extra_ca_certs_file) environment variable)|
 | `tlsOptions.ca` | `string` /  `array` / `Buffer` | `undefined` | Override the trusted CA certificates provided by Node. Refer to [tls.createSecureContext](https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options) |
-| `getConnectionId` | `function` | `function(request, response) { return utils.uuidv4(); }` | Function to generate custom connection IDs, based optionally on the request and response objects. |
+| `getConnectionId` | `function` | `function(request, response) { return utils.uuidv4(); }` | Function to generate custom connection IDs, based optionally on the request and response objects. Used by the default implementation of `getProxyId` to keep backwards compatibility. *deprecated* |
+| `getProxyId` | `function` | `function(request, response) { if (!request.connection.id) { request.connection.id = options.getConnectionId(request, response); } return request.connection.id; }` | Function to generate custom proxy cache IDs, based optionally on the request and response objects. |
+| `getCachedUserData` | `function` | `function(request, response) { return request.connection.ntlm; }` | Function to return the cached NTLM user data. |
+| `addCachedUserData` | `function` | `function(request, response, userData) { request.connection.ntlm = userData; }` | Function to cache the NTLM user data. |
 
 ## logging (examples)
 <a name="logging" />

--- a/lib/express-ntlm.js
+++ b/lib/express-ntlm.js
@@ -43,6 +43,21 @@ module.exports = function(options) {
 
         getConnectionId(request, response) {
             return utils.uuidv4();
+        },
+
+        getProxyId(request, response) {
+            if (!request.connection.id) {
+                request.connection.id = options.getConnectionId(request, response);
+            }
+
+            return request.connection.id;
+        },
+
+        getCachedUserData(request, response) {
+            return request.connection.ntlm;
+        },
+        addCachedUserData(request, response, userData) {
+            request.connection.ntlm = userData;
         }
     }, options);
 
@@ -137,7 +152,9 @@ module.exports = function(options) {
     }
 
     function handle_type1(request, response, next, ntlm_message, callback) {
-        cache.remove(request.connection.id);
+        var proxyId = options.getProxyId(request, response);
+
+        cache.remove(proxyId);
         cache.clean();
 
         connect_to_proxy(ntlm_message, function(error, proxy, challenge) {
@@ -147,14 +164,15 @@ module.exports = function(options) {
             response.setHeader('WWW-Authenticate', 'NTLM ' + challenge.toString('base64'));
             response.end();
 
-            cache.add(request.connection.id, proxy);
+            cache.add(proxyId, proxy);
 
             return callback();
         });
     }
 
     function handle_type3(request, response, next, ntlm_message, callback) {
-        var proxy = cache.get_proxy(request.connection.id);
+        var proxyId = options.getProxyId(request, response),
+            proxy = cache.get_proxy(proxyId);
 
         var userDomainWorkstation = parse_ntlm_authenticate(ntlm_message),
             user = userDomainWorkstation[0],
@@ -176,10 +194,10 @@ module.exports = function(options) {
 
             request.ntlm = userData;
             response.locals.ntlm = userData;
-            request.connection.ntlm = userData;
+            options.addCachedUserData(request, response, userData);
 
             if (!result) {
-                cache.remove(request.connection.id);
+                cache.remove(proxyId);
                 options.debug(options.prefix, 'User ' + domain + '/' + user + ' authentication for URI ' + request.protocol + '://' + request.get('host') + request.originalUrl);
                 return options.forbidden(request, response, next);
             } else {
@@ -190,13 +208,9 @@ module.exports = function(options) {
     }
 
     return function(request, response, next) {
-        if (!request.connection.id) {
-            request.connection.id = options.getConnectionId(request, response);
-        }
-
         var auth_headers = request.headers.authorization;
 
-        var user = request.connection.ntlm;
+        var user = options.getCachedUserData(request, response);
         if (user && user.Authenticated) {
             options.debug(options.prefix, 'Connection already authenticated ' + user.DomainName + '/' + user.UserName);
             if (auth_headers) {
@@ -241,7 +255,7 @@ module.exports = function(options) {
         }
 
         if (ntlm_version === 3) {
-            if (cache.get_proxy(request.connection.id) !== null) {
+            if (cache.get_proxy(options.getProxyId(request, response)) !== null) {
                 return handle_type3(request, response, next, ah_data[1], function(error) {
                     if (error) {
                         options.debug(options.prefix, error.stack);


### PR DESCRIPTION
Hello,

Thank you very much for providing this middleware.

I have recently introduced a reverse proxy to my application and run into the issues you described in the readme.

I could not find a solution to configure the proxy without also breaking the reasons for introducing it so I have been looking into the plugin for a possible solution.

My idea is to allow the application to take ownership of the data (proxy ID and cached user data) that is currently added to the connection and so fix the problems caused by shared connections.

In my case I already have an identifier for the user and only need the middleware for authentication. 

So with the proposed new options it would become possible to keep the current state of the middleware working while also allowing the usage behind a proxy if the application is able to distinguish its users.

If you have any questions or requests please let me now.

Thank you in advance